### PR TITLE
correct a translation

### DIFF
--- a/hp/account/locale/de/LC_MESSAGES/django.po
+++ b/hp/account/locale/de/LC_MESSAGES/django.po
@@ -415,8 +415,8 @@ msgstr ""
 #: templates/account/confirm/set_email.txt:8
 msgid "If you haven't made this change, simply disregard this email."
 msgstr ""
-"Falls sie ihr Passwort nicht ändern wollten, können sie diese E-Mail einfach "
-"ignorieren."
+"Falls sie diese Änderung nicht vorgenommen haben, können sie diese E-Mail "
+"einfach ignorieren."
 
 #: templates/account/confirm/reset_password.txt:3
 #, python-format


### PR DESCRIPTION
I stumbled across this:
> Bestätigen sie die neue E-Mail-Adresse ...
> [...]
> Falls sie ihr Passwort nicht ändern wollten, können sie diese E-Mail einfach ignorieren.

So I updated the corresponding translation.